### PR TITLE
Make the generated number more visible.

### DIFF
--- a/css/styling.css
+++ b/css/styling.css
@@ -12,3 +12,8 @@
 div[data-role="footer"] {
 	display: none;
 }
+
+#accounts h3 {
+	font-family: monospace;
+	font-size: 200%;
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
 		<meta name="description" content="GAuth Authenticator">
 		<meta name="HandheldFriendly" content="True">
 		<meta http-equiv="cleartype" content="on">
-		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta name="viewport" content="width=device-width,
+				initial-scale=2, maximum-scale=4, user-scalable=yes">
 		<link rel="stylesheet" href="css/jquery.mobile-1.2.0.min.css" />
 		<link rel="stylesheet" href="css/styling.css" />
 		<!-- purposely at the top -->


### PR DESCRIPTION
I believe my bad eyes and bad light conditions of my office are not that
unique, so making the generated keys more visible could be useful.

And yes, 'font-family: monospace' is rather brutal thing, but I believe
it really helps
(http://www.joelonsoftware.com/uibook/chapters/fog0000000063.html)

Actually, after thinking about it and looking at how are numbers
presented on the Android Google Authenticatior
(https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2)
it seems to me that we can go all the way to xx-large.

Signed-off-by: Matěj Cepl mcepl@redhat.com
