### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/gbraad/html5-google-authenticator.png?label=ready&title=Ready)](https://waffle.io/gbraad/html5-google-authenticator)
 GAuth Authenticator
 ===================
 


### PR DESCRIPTION
Thus merge add a badge indicating the number of issues in the ready column of the waffle.io board at https://waffle.io/gbraad/html5-google-authenticator
