### PR TITLE
Fix "cannot call methods on listview" error.

### DIFF
--- a/js/gauth.js
+++ b/js/gauth.js
@@ -162,7 +162,7 @@
 				// Add HTML element
 				accountList.append(accElem);
 			});
-			accountList.listview('refresh');
+			accountList.listview().listview('refresh');
 		};
 
 		var deleteAccount = function(index) {


### PR DESCRIPTION
This change fixes the following error, at least on Mac Chrome 37:

"Uncaught Error: cannot call methods on listview prior to initialization;
attempted to call method 'refresh' jquery-1.8.2.min.js:2"
