### PR TITLE
Added support for secrets with odd-nibble counts

### DIFF
--- a/js/gauth.js
+++ b/js/gauth.js
@@ -82,6 +82,12 @@
 
         var generate = function(secret, epoch) {
             var key = base32tohex(secret);
+
+            // HMAC generator requires secret key to have even number of nibbles
+            if (key.length % 2 != 0) {
+                key += '0';
+            }
+
             // If no time is given, set time as now
             if(typeof epoch === 'undefined') {
                 epoch = Math.round(new Date().getTime() / 1000.0);

--- a/js/gauth.js
+++ b/js/gauth.js
@@ -84,7 +84,7 @@
             var key = base32tohex(secret);
 
             // HMAC generator requires secret key to have even number of nibbles
-            if (key.length % 2 != 0) {
+            if (key.length % 2 !== 0) {
                 key += '0';
             }
 


### PR DESCRIPTION
Here is a fix for a problem I noticed with (base32-encoded) secret keys that did not resolve to an even number of nibbles.  The issue was that the app would always generate a code of 0 for such keys, no matter the current system time.  A workaround was to append A's to such a key until the number of bits it represented became divisible by 8.

An example of a troublesome key is "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" (52 X's), and a workaround for this key was to append 4 A's to the key to bring the total number of bits represented from 160 to 180, the latter value being divisible by 8 and hence representing an even number of nibbles.

With this fix, such workarounds are no longer necessary.

I have tested my update against Google's Authenticator app, and verified that app and Gauth generate the same TOTP codes for the same odd-nibbled secret keys.
