### PR TITLE
Allows text selection

### DIFF
--- a/css/styling.css
+++ b/css/styling.css
@@ -48,3 +48,13 @@ footer, div[data-role="footer"] {
 #addButton {
     display: none;
 }
+
+.ui-listview .ui-li-aside {
+  height: 100%;
+  top: 0;
+}
+
+.ui-listview .ui-btn-icon-notext {
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/js/gauth.js
+++ b/js/gauth.js
@@ -176,11 +176,11 @@
                 var key = keyUtilities.generate(account.secret);
 
                 // Construct HTML
-                var detLink = $('<a href="#"><h3>' + key + '</h3><p>' + account.name + '</p></a>');
+                var detLink = $('<h3>' + key + '</h3><p>' + account.name + '</p>');
                 var accElem = $('<li data-icon="false">').append(detLink);
 
                 if(editingEnabled) {
-                    var delLink = $('<a data-icon="delete" href="#"></a>');
+                    var delLink = $('<p class="ui-li-aside"><a class="ui-btn-icon-notext ui-icon-delete" href="#"></a></p>');
                     delLink.click(function () {
                         deleteAccount(index);
                     });


### PR DESCRIPTION
I use gauth everyday in a desktop browser, and it would be very convenient to allow text selection.
This allows user to copy-paste one-time passwords.

Tested with latest Chrome and Firefox.