### PR TITLE
Keeping the Remaining Seconds Header Sticky

### DIFF
--- a/css/styling.css
+++ b/css/styling.css
@@ -28,6 +28,14 @@ footer, div[data-role="footer"] {
    border-radius: 0 !important;
 }
 
+.ui-mobile .ui-page-active{
+    overflow-x: visible;
+}
+
+.ui-content{
+    overflow-x: visible;
+}
+
 #panelheader {
     background-color: #1593f9;
     border: none;
@@ -43,6 +51,12 @@ footer, div[data-role="footer"] {
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     box-shadow: none;
+}
+
+#accountsHeader{
+    position:sticky;
+    top:0;
+    z-index:3;
 }
 
 #addButton {


### PR DESCRIPTION
As I scroll down, the header that contains the remaining seconds disappears and there is no way of knowing that only a few seconds are left for me to paste the code until I get told that the OTP I've used is incorrect.

I added some styles to make the remaining seconds header sticky to be visible when the page is scrolled.

